### PR TITLE
feat(todo): add clone feature to Todo class with docstring, test suite,

### DIFF
--- a/src/task/task.py
+++ b/src/task/task.py
@@ -115,7 +115,7 @@ class Todo:
             self._idx = value
 
     @property
-    def deadline(self) -> date:
+    def deadline(self) -> date | None:
         """Get the task deadline.
 
         Returns:
@@ -224,3 +224,37 @@ class Todo:
         tag_ = self._normalize(tag)
         if tag_ in self.tags:
             self.tags.remove(tag_)
+
+    def clone(self) -> Todo:
+        """Create a new copy of the current Todo instance with updated timestamps.
+
+        This method performs a deep clone of the task while preserving all
+        user-defined attributes (description, priority, status, and tags).
+        The `created_at` field is refreshed to the current UTC time, while
+        the `deadline` is carried over only if it is not in the past.
+        A new unique UUID is automatically generated for the cloned task.
+
+        Returns:
+            Todo: A new `Todo` instance representing a cloned copy of the current task.
+
+        Example:
+            >>> todo = Todo(description="Write tests", tags=["python"])
+            >>> cloned = todo.clone()
+            >>> cloned is todo
+            False
+            >>> cloned.description == todo.description
+            True
+            >>> cloned.created_at > todo.created_at
+            True
+        """
+        created_at = datetime.now(tz=UTC)
+        deadline = None if self.deadline and self.deadline < created_at.date() else self.deadline
+
+        return Todo(
+            description=self.description,
+            priority=self.priority,
+            created_at=created_at,
+            deadline=deadline,
+            tags=self.tags.copy(),
+            status=self.status,
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,37 @@
+import datetime
+from typing import TYPE_CHECKING
+
+import pytest
+
+from src.enums.priority_enum import PriorityEnum
+from src.enums.status_enum import StatusEnum
+import src.task.task as task_module
+from src.task.task import Todo
+
+
+if TYPE_CHECKING:  # pragma: no cover
+    from _pytest.monkeypatch import MonkeyPatch
+
+
+class _FixedDateTime(datetime.datetime):
+    _fixed_now = datetime.datetime(2025, 12, 11, 21, 30, 0, tzinfo=datetime.UTC)
+
+    @classmethod
+    def now(cls, tz: datetime.tzinfo | None = None) -> datetime.datetime:
+        return cls._fixed_now if tz is None else cls._fixed_now.astimezone(tz)
+
+
+@pytest.fixture(autouse=True)
+def _freeze_datetime(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(task_module, "datetime", _FixedDateTime)
+
+
+@pytest.fixture
+def basic_todo() -> Todo:
+    return Todo(
+        description="Write tests",
+        priority=PriorityEnum.LOW,
+        deadline=(_FixedDateTime.now(tz=datetime.UTC) + datetime.timedelta(days=10)).date(),
+        tags=["Python", "JavaScript", "Java"],
+        status=StatusEnum.IN_PROGRESS,
+    )

--- a/tests/task/test_clone.py
+++ b/tests/task/test_clone.py
@@ -1,0 +1,36 @@
+from datetime import UTC, timedelta
+from typing import TYPE_CHECKING
+
+from tests.conftest import _FixedDateTime
+
+
+if TYPE_CHECKING:  # pragma: no cover
+    from src.task.task import Todo
+
+
+def test_clone_copies_core_fields_and_sets_created_at_now(basic_todo: Todo) -> None:
+    new_todo = basic_todo.clone()
+
+    assert new_todo is not basic_todo
+    assert new_todo.description == basic_todo.description
+    assert new_todo.priority == basic_todo.priority
+    assert new_todo.deadline == basic_todo.deadline
+    assert new_todo.tags == basic_todo.tags
+    assert new_todo.tags is not basic_todo.tags
+    assert new_todo.status == basic_todo.status
+    assert new_todo.created_at == _FixedDateTime.now(tz=UTC)
+    assert new_todo.idx != basic_todo.idx
+
+
+def test_clone_nulls_past_deadline(basic_todo: Todo) -> None:
+    basic_todo._deadline = (_FixedDateTime.now(tz=UTC) - timedelta(days=10)).date()
+    new_todo = basic_todo.clone()
+
+    assert new_todo.deadline is None
+
+
+def test_clone_preserves_none_deadline(basic_todo: Todo) -> None:
+    basic_todo._deadline = None
+    new_todo = basic_todo.clone()
+
+    assert new_todo.deadline is None


### PR DESCRIPTION
conftest

## Summary
- add `clone` feature for `Todo` class /clone task with validation for wrong or None deadline date/.
- add `docstring` for `clone`. 
- add test suite for `clone`.
- add `conftest.py` with fixtures for fixed datetime and reusable `Todo` objects.

## Context / Issue
- GitHub project / Issue link(s): [TD-19](https://github.com/orgs/KoltanPL/projects/1/views/1?pane=issue&itemId=138417576&issue=KoltanPL%7Ctodo%7C19)


## Type of change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Performance improvement
- [ ] Security hardening
- [ ] CI/CD / Tooling
- [ ] Documentation only
- [ ] Chore / Maintenance
- [ ] Revert

## Scope (modules/services/packages)
<!-- e.g., api, worker, auth, web, infra, shared-lib -->

## Implementation notes
<!-- Key decisions, algorithms, data structures, trade-offs -->

## Screenshots / Demos (optional)
<!-- UI, logs, traces, benchmarks -->

## API changes
- [ ] Public API changed
- [ ] New endpoint(s)
- [ ] Request/response schema changes
- [ ] DB schema/migration
- [ ] Backward compatible
- [ ] Breaking change (see Migration)

**Details:**
```diff
# endpoints / schemas / CLI flags