### PR TITLE
feat(todo): string representation for Todo object

### DIFF
--- a/tests/task/test_format.py
+++ b/tests/task/test_format.py
@@ -1,0 +1,63 @@
+from datetime import UTC, timedelta
+
+from src.enums.status_enum import StatusEnum
+from src.task.task import Todo
+from tests.conftest import _FixedDateTime
+
+
+def test_format_short(basic_todo: Todo) -> None:
+    formatted = format(basic_todo, "short")
+
+    assert formatted == "[✗] Write tests (10 days left)"
+
+
+def test_format_long(basic_todo: Todo) -> None:
+    formatted = format(basic_todo, "long")
+
+    assert f"{type(basic_todo).__name__} '{basic_todo.description}'" in formatted
+    assert f"idx: {basic_todo.idx}" in formatted
+    assert f"status: {basic_todo.status.value}" in formatted
+    assert "created_at:" in formatted
+    assert f"deadline: {basic_todo.deadline}" in formatted
+    assert f"priority: {basic_todo.priority.name.capitalize()}" in formatted
+
+    for t in basic_todo.tags:
+        assert f"🏷️ {t}" in formatted
+
+
+def test_format_falls_back_to_str(basic_todo: Todo) -> None:
+    formatted = format(basic_todo, "unknown-format")
+    assert formatted == str(basic_todo)
+
+
+def test_format_empty_uses_str(basic_todo: Todo) -> None:
+    formatted = format(basic_todo, "")
+    assert formatted == str(basic_todo)
+
+
+def test_format_short_status_symbol() -> None:
+    todo_done = Todo(
+        description="Test",
+        status=StatusEnum.COMPLETED,
+        deadline=_FixedDateTime.now(tz=UTC).date() + timedelta(days=5),
+    )
+
+    todo_pending = Todo(
+        description="Test",
+        status=StatusEnum.TODO,
+        deadline=_FixedDateTime.now(tz=UTC).date() + timedelta(days=5),
+    )
+
+    assert format(todo_done, "short").startswith("[✓]")
+    assert format(todo_pending, "short").startswith("[✗]")
+
+
+def test_format_tags_empty() -> None:
+    todo = Todo(
+        description="No tags",
+        tags=None,
+        deadline=_FixedDateTime.now(tz=UTC).date() + timedelta(days=3),
+    )
+
+    formatted_long = format(todo, "long")
+    assert "tags:" in formatted_long

--- a/tests/task/test_repr.py
+++ b/tests/task/test_repr.py
@@ -1,0 +1,80 @@
+from datetime import UTC, date, datetime
+from uuid import UUID
+
+import pytest
+
+from src.enums.priority_enum import PriorityEnum
+from src.enums.status_enum import StatusEnum
+from src.task.task import Todo
+
+
+def test_repr_contains_all_fields() -> None:
+    my_todo = Todo(
+        description="Write tests",
+        priority=PriorityEnum.HIGH,
+        created_at=datetime(2025, 11, 16, 12, 0, tzinfo=UTC),
+        deadline=date(2026, 1, 15),
+        tags=["python", "testing"],
+        status=StatusEnum.TODO,
+        idx=UUID("931f66ba-99a0-484e-8b19-4866c2f51721"),
+    )
+
+    r = repr(my_todo)
+
+    assert (
+        r == "Todo(description='Write tests', priority=PriorityEnum(3), "
+        "created_at=datetime.datetime(2025, 11, 16, 12, 0, tzinfo=datetime.timezone.utc), "
+        "deadline=datetime.date(2026, 1, 15), tags=['python', 'testing'], status=StatusEnum(\"todo\"), "
+        "idx=UUID('931f66ba-99a0-484e-8b19-4866c2f51721'))"
+    )
+
+
+def test_repr_contains_correct_values() -> None:
+    my_todo = Todo(
+        description="Write tests",
+        priority=PriorityEnum.LOW,
+        created_at=datetime(2025, 11, 16, 12, 0, tzinfo=UTC),
+        deadline=date(2026, 1, 15),
+        tags=["python", "testing"],
+        status=StatusEnum.IN_PROGRESS,
+        idx=UUID("931f66ba-99a0-484e-8b19-4866c2f51721"),
+    )
+
+    r = repr(my_todo)
+
+    assert "description='Write tests'" in r
+    assert "priority=PriorityEnum(1)" in r
+    assert "created_at=datetime.datetime(2025, 11, 16, 12, 0, tzinfo=datetime.timezone.utc)" in r
+    assert "deadline=datetime.date(2026, 1, 15)" in r
+    assert "tags=['python', 'testing']" in r
+    assert "deadline=datetime.date(2026, 1, 15)" in r
+    assert "idx=UUID('931f66ba-99a0-484e-8b19-4866c2f51721')" in r
+
+
+@pytest.mark.parametrize(
+    "priority",
+    [
+        PriorityEnum.HIGH,
+        PriorityEnum.MEDIUM,
+        PriorityEnum.LOW,
+    ],
+)
+def test_repr_priority_values(priority: PriorityEnum) -> None:
+    my_todo = Todo(description="Write tests", priority=priority)
+    r = repr(my_todo)
+
+    expected_fragment = f"priority=PriorityEnum({priority.value})"
+    assert expected_fragment in r
+
+
+def test_repr_handles_none_values() -> None:
+    my_todo = Todo(
+        description="Write tests",
+        deadline=None,
+        tags=None,
+    )
+
+    r = repr(my_todo)
+
+    assert "deadline=None" in r
+    assert "tags=[]" in r

--- a/tests/task/test_str.py
+++ b/tests/task/test_str.py
@@ -1,0 +1,49 @@
+from datetime import date
+
+import pytest
+
+from src.enums.priority_enum import PriorityEnum
+from src.task.task import Todo
+
+
+def test_str_all_attributes() -> None:
+    my_todo = Todo(
+        description="WRITE testS", priority=PriorityEnum.HIGH, deadline=date(2025, 12, 15), tags=["python", "testing"]
+    )
+
+    assert str(my_todo) == "🔴  Write tests | 📅  2025-12-15 | 🏷️ python, 🏷️ testing"
+
+
+def test_str_no_tags() -> None:
+    my_todo = Todo(
+        description="WRITE testS",
+        priority=PriorityEnum.HIGH,
+        deadline=date(2025, 12, 15),
+    )
+
+    assert str(my_todo) == "🔴  Write tests | 📅  2025-12-15 "
+
+
+def test_str_no_deadline() -> None:
+    my_todo = Todo(description="WRITE testS", priority=PriorityEnum.HIGH, deadline=None)
+
+    assert str(my_todo) == "🔴  Write tests | 📅  - "
+
+
+@pytest.mark.parametrize(
+    ("priority", "expected_emoji"),
+    [
+        (PriorityEnum.HIGH, "🔴"),
+        (PriorityEnum.MEDIUM, "🟡"),
+        (PriorityEnum.LOW, "🟢"),
+    ],
+)
+def test_str_priority_emoji(priority: PriorityEnum, expected_emoji: str) -> None:
+    my_todo = Todo(
+        description="WRITE testS",
+        priority=priority,
+    )
+
+    result = str(my_todo)
+
+    assert result.startswith(expected_emoji)


### PR DESCRIPTION
## Summary
- add string representation for `Todo` object with docstrings (`__repr__`, `__str__`, `__format__`).
- add tests suite for `__repr__`, `__str__`, `__format__`.

## Context / Issue
- GitHub project / Issue link(s): [TD-21](https://github.com/orgs/KoltanPL/projects/1/views/1?pane=issue&itemId=139217617&issue=KoltanPL%7Ctodo%7C21)


## Type of change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Performance improvement
- [ ] Security hardening
- [ ] CI/CD / Tooling
- [ ] Documentation only
- [ ] Chore / Maintenance
- [ ] Revert

## Scope (modules/services/packages)
<!-- e.g., api, worker, auth, web, infra, shared-lib -->

## Implementation notes
<!-- Key decisions, algorithms, data structures, trade-offs -->

## Screenshots / Demos (optional)
<!-- UI, logs, traces, benchmarks -->

## API changes
- [ ] Public API changed
- [ ] New endpoint(s)
- [ ] Request/response schema changes
- [ ] DB schema/migration
- [ ] Backward compatible
- [ ] Breaking change (see Migration)

**Details:**
```diff
# endpoints / schemas / CLI flags